### PR TITLE
chore: update vercel postgres dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ No external API keys are required for Yahoo Finance.
 
 ### 3. Database setup
 
-Run the schema against your database using Drizzle Kit:
+Run the schema against your database using Drizzle Kit (the `db:push` script wraps `drizzle-kit push`):
 
 ```bash
 npm run db:push

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@radix-ui/react-slot": "1.0.2",
     "@radix-ui/react-tabs": "1.0.4",
     "@radix-ui/react-toast": "1.1.5",
-    "@vercel/postgres": "0.6.0",
+    "@vercel/postgres": "0.10.0",
     "class-variance-authority": "0.7.0",
     "clsx": "2.1.0",
     "date-fns": "3.6.0",


### PR DESCRIPTION
## Summary
- bump @vercel/postgres to the latest stable release
- document that the db:push script runs drizzle-kit push in the database setup guide

## Testing
- npm install *(fails: registry access is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca60399f588329afbd83dab9bb13c0