### PR TITLE
Add Radix UI icons dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,51 @@
+{
+  "name": "stock-side-bets",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "stock-side-bets",
+      "version": "0.1.0",
+      "dependencies": {
+        "@hookform/resolvers": "3.3.4",
+        "@radix-ui/react-icons": "^1.3.0",
+        "@radix-ui/react-label": "2.0.2",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-tabs": "1.0.4",
+        "@radix-ui/react-toast": "1.1.5",
+        "@vercel/postgres": "0.10.0",
+        "class-variance-authority": "0.7.0",
+        "clsx": "2.1.0",
+        "date-fns": "3.6.0",
+        "drizzle-orm": "0.30.10",
+        "lucide-react": "0.378.0",
+        "next": "14.2.3",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "react-hook-form": "7.51.2",
+        "tailwind-merge": "2.3.0",
+        "tailwindcss-animate": "1.0.7",
+        "yahoo-finance2": "2.11.0",
+        "zod": "3.23.8"
+      },
+      "devDependencies": {
+        "@types/node": "20.12.7",
+        "@types/react": "18.2.21",
+        "@types/react-dom": "18.2.7",
+        "@typescript-eslint/eslint-plugin": "7.6.0",
+        "@typescript-eslint/parser": "7.6.0",
+        "autoprefixer": "10.4.17",
+        "drizzle-kit": "0.21.4",
+        "eslint": "8.57.0",
+        "eslint-config-next": "14.2.3",
+        "postcss": "8.4.35",
+        "tailwindcss": "3.4.3",
+        "ts-node": "10.9.2",
+        "typescript": "5.4.5",
+        "vite-tsconfig-paths": "4.3.1",
+        "vitest": "1.5.2"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "3.3.4",
+    "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "2.0.2",
     "@radix-ui/react-slot": "1.0.2",
     "@radix-ui/react-tabs": "1.0.4",


### PR DESCRIPTION
## Summary
- add the `@radix-ui/react-icons` package to the project dependencies so UI components can consume the icon set
- include a package-lock.json stub that mirrors the declared dependencies

## Testing
- `npm install @radix-ui/react-icons` *(fails with 403 Forbidden when contacting the registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca636f93bc8329b9bd704fc6a158e8