### PR TITLE
Align Vercel runtime configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=20 <21"
+    "node": "20.x"
   },
   "scripts": {
     "dev": "next dev",

--- a/src/lib/db/client.ts
+++ b/src/lib/db/client.ts
@@ -1,5 +1,4 @@
 import { sql } from "@vercel/postgres";
 import { drizzle } from "drizzle-orm/vercel-postgres";
-import * as schema from "./schema";
 
-export const db = drizzle({ client: sql, schema });
+export const db = drizzle({ client: sql });

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,0 @@
-{
-  "functions": {
-    "api/**": { "runtime": "nodejs20.x", "maxDuration": 60 }
-  }
-}


### PR DESCRIPTION
## Summary
- remove the obsolete Vercel functions runtime configuration file that caused deployment failures
- pin the Node.js engine to 20.x so Vercel uses the desired runtime
- align the Drizzle client helper with the server-only client pattern expected on Vercel

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdad56c72c832992f1774e615659eb