### PR TITLE
Harden settlement logic and trading day handling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,1 @@
-{
-  "extends": ["next/core-web-vitals", "next/typescript"]
-}
+{"extends": ["next/core-web-vitals"]}

--- a/README.md
+++ b/README.md
@@ -94,3 +94,8 @@ To automatically settle expired bets, trigger the `/api/check-due` endpoint via 
 - `npm run db:seed` – seed sample data.
 - `npm run db:studio` – open the Drizzle Studio UI.
 - `npm run db:generate` – generate SQL migrations from schema changes.
+
+## Troubleshooting
+
+- Database migrations rely on `DATABASE_URL`, while the runtime uses `POSTGRES_URL` (pooled) and `POSTGRES_URL_NON_POOLING`. If any of these variables are missing the server will throw an explicit error—double check your `.env` values when running locally.
+- All API routes that talk to Postgres execute in the Node.js runtime. If you encounter `fs`/`crypto` errors in production it typically means the route fell back to the Edge runtime; redeploy after ensuring the `runtime = 'nodejs'` exports are preserved.

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,11 +1,17 @@
 import "dotenv/config";
 import { defineConfig } from "drizzle-kit";
 
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+  throw new Error("DATABASE_URL is required to run Drizzle migrations. Set it in your environment before running drizzle-kit.");
+}
+
 export default defineConfig({
   schema: "./src/lib/db/schema.ts",
   out: "./drizzle",
   dialect: "postgresql",
   dbCredentials: {
-    url: process.env.DATABASE_URL ?? process.env.POSTGRES_URL!
+    url: databaseUrl
   }
 });

--- a/drizzle/0000_bets.sql
+++ b/drizzle/0000_bets.sql
@@ -1,0 +1,23 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TYPE "bet_status" AS ENUM ('OPEN', 'SETTLED', 'INVALID');
+
+CREATE TABLE "bets" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "created_at" timestamp NOT NULL DEFAULT now(),
+  "updated_at" timestamp NOT NULL DEFAULT now(),
+  "settled_at" timestamp,
+  "settlement_tx_id" uuid,
+  "bettor_a" varchar(80) NOT NULL,
+  "bettor_b" varchar(80) NOT NULL,
+  "ticker_a" varchar(16) NOT NULL,
+  "ticker_b" varchar(16) NOT NULL,
+  "start_date" date NOT NULL,
+  "end_date" date NOT NULL,
+  "status" "bet_status" NOT NULL DEFAULT 'OPEN',
+  "settlement_error" text,
+  "result" jsonb DEFAULT null,
+  CONSTRAINT "chk_bets_end_after_start" CHECK ("end_date" > "start_date")
+);
+
+CREATE INDEX "idx_bets_status_enddate" ON "bets" ("status", "end_date");

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "class-variance-authority": "0.7.0",
         "clsx": "2.1.0",
         "date-fns": "3.6.0",
+        "date-fns-tz": "^3.2.0",
         "drizzle-orm": "0.30.10",
         "lucide-react": "0.378.0",
         "next": "14.2.3",
@@ -3929,6 +3930,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "class-variance-authority": "0.7.0",
     "clsx": "2.1.0",
     "date-fns": "3.6.0",
+    "date-fns-tz": "^3.2.0",
     "drizzle-orm": "0.30.10",
     "lucide-react": "0.378.0",
     "next": "14.2.3",
@@ -52,7 +53,7 @@
     "tailwindcss": "3.4.3",
     "ts-node": "10.9.2",
     "typescript": "5.4.5",
-    "vitest": "1.5.2",
-    "vite-tsconfig-paths": "4.3.1"
+    "vite-tsconfig-paths": "4.3.1",
+    "vitest": "1.5.2"
   }
 }

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,5 +1,8 @@
 import "dotenv/config";
-import { addDays } from "date-fns";
+import { randomUUID } from "crypto";
+
+import { addDays, formatISO } from "date-fns";
+
 import { db } from "@/lib/db";
 import { bets } from "@/lib/db/schema";
 
@@ -11,6 +14,12 @@ async function main() {
   const start = addDays(today, -10);
   const end = addDays(today, -3);
 
+  const quoteSnapshot = (price: number, daysAgo: number) => ({
+    date: formatISO(addDays(today, -daysAgo)),
+    close: price,
+    adjClose: price
+  });
+
   await db.insert(bets).values([
     {
       bettorA: "Alice",
@@ -19,7 +28,7 @@ async function main() {
       tickerB: "MSFT",
       startDate: start,
       endDate: end,
-      status: "open"
+      status: "OPEN"
     },
     {
       bettorA: "Charlie",
@@ -28,10 +37,24 @@ async function main() {
       tickerB: "AMZN",
       startDate: addDays(today, -30),
       endDate: addDays(today, -1),
-      status: "completed",
+      status: "SETTLED",
+      settledAt: today,
+      settlementTxId: randomUUID(),
       result: {
-        aReturn: 0.05,
-        bReturn: 0.02,
+        a: {
+          ticker: "GOOGL",
+          start: quoteSnapshot(100, 30),
+          end: quoteSnapshot(105, 1),
+          raw: 0.05,
+          rounded: 0.05
+        },
+        b: {
+          ticker: "AMZN",
+          start: quoteSnapshot(90, 30),
+          end: quoteSnapshot(92, 1),
+          raw: 0.0222,
+          rounded: 0.0222
+        },
         winner: "A"
       }
     }

--- a/src/app/api/check-due/route.ts
+++ b/src/app/api/check-due/route.ts
@@ -1,45 +1,191 @@
-import { NextResponse } from "next/server";
-import { and, eq, lt } from "drizzle-orm";
-import { startOfDay, subMilliseconds } from "date-fns";
+import { NextRequest, NextResponse } from "next/server";
+import { and, asc, eq, gt, isNull, lt, lte, or } from "drizzle-orm";
+import { formatISO, parseISO } from "date-fns";
+import { isValid } from "date-fns";
+import { z, ZodError } from "zod";
+
 import { bets } from "@/lib/db";
 import { db } from "@/lib/db/client";
 import { BetNotMaturedError, settleBet } from "@/lib/services/settle-bet";
+import { checkDueQuerySchema } from "@/lib/validation";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-export async function POST() {
-  const today = startOfDay(new Date());
-  const endOfYesterday = subMilliseconds(today, 1);
+const uuidSchema = z.string().uuid();
 
-  try {
-    const dueBets = await db
-      .select()
-      .from(bets)
-      .where(and(eq(bets.status, "open"), lt(bets.endDate, endOfYesterday)));
+type ParsedCursor = {
+  endDate: Date;
+  id: string;
+  raw: string;
+};
 
-    const settled = [] as typeof dueBets;
-    for (const bet of dueBets) {
-      try {
-        const updated = await settleBet(bet);
-        if (updated) {
-          settled.push(updated);
-        }
-      } catch (error) {
-        if (error instanceof BetNotMaturedError) {
-          continue;
-        }
-        throw error;
+function parseCursor(value: string): ParsedCursor {
+  const [datePart, idPart] = value.split("|");
+  if (!datePart || !idPart) {
+    throw new Error("Cursor must be in the format <endDate>|<id>");
+  }
+
+  const idResult = uuidSchema.safeParse(idPart);
+  if (!idResult.success) {
+    throw new Error("Cursor id must be a valid UUID");
+  }
+
+  const parsedDate = parseISO(datePart);
+  if (!isValid(parsedDate)) {
+    throw new Error("Cursor date must be a valid ISO date (YYYY-MM-DD)");
+  }
+
+  return { endDate: parsedDate, id: idResult.data, raw: value };
+}
+
+function methodNotAllowed() {
+  return NextResponse.json(
+    { error: "Method Not Allowed" },
+    {
+      status: 405,
+      headers: {
+        Allow: "POST"
       }
     }
+  );
+}
 
-    return NextResponse.json({ count: settled.length, bets: settled });
-  } catch (error) {
-    console.error("Failed to settle due bets", error);
-    if (error instanceof Error) {
-      return NextResponse.json({ error: error.message }, { status: 500 });
+export async function POST(req: NextRequest) {
+  try {
+    const { searchParams } = req.nextUrl;
+    const query = checkDueQuerySchema.parse({
+      limit: searchParams.get("limit") ?? undefined,
+      cursor: searchParams.get("cursor") ?? undefined
+    });
+
+    let cursor: ParsedCursor | null = null;
+    if (query.cursor) {
+      try {
+        cursor = parseCursor(query.cursor);
+      } catch (cursorError) {
+        return NextResponse.json(
+          { error: cursorError instanceof Error ? cursorError.message : "Invalid cursor" },
+          { status: 400 }
+        );
+      }
     }
-    return NextResponse.json({ error: "Unable to settle bets" }, { status: 500 });
+    const limit = query.limit;
+    const todayIso = formatISO(new Date(), { representation: "date" });
+
+    const result = await db.transaction(async (tx) => {
+      const conditions = [
+        eq(bets.status, "OPEN"),
+        isNull(bets.settledAt),
+        lte(bets.endDate, todayIso)
+      ];
+
+      if (cursor) {
+        const cursorDateIso = formatISO(cursor.endDate, { representation: "date" });
+        conditions.push(
+          or(
+            lt(bets.endDate, cursorDateIso),
+            and(eq(bets.endDate, cursorDateIso), gt(bets.id, cursor.id))
+          )
+        );
+      }
+
+      const dueBets = await tx
+        .select()
+        .from(bets)
+        .where(and(...conditions))
+        .orderBy(asc(bets.endDate), asc(bets.id))
+        .limit(limit)
+        .for("update", { skipLocked: true });
+
+      const summary = {
+        scanned: dueBets.length,
+        settled: 0,
+        pending: 0,
+        errors: 0
+      };
+
+      const processed: Array<{
+        id: string;
+        status: string;
+        reason?: string | null;
+      }> = [];
+
+      for (const bet of dueBets) {
+        try {
+          const outcome = await settleBet(bet, tx);
+          processed.push({
+            id: outcome.bet.id,
+            status: outcome.status,
+            reason: outcome.bet.settlementError ?? null
+          });
+
+          if (outcome.status === "SETTLED") {
+            summary.settled += 1;
+          } else if (outcome.status === "PENDING") {
+            summary.pending += 1;
+          } else {
+            summary.errors += 1;
+          }
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Unknown error";
+          if (error instanceof BetNotMaturedError) {
+            summary.pending += 1;
+            processed.push({ id: bet.id, status: "PENDING", reason: message });
+            continue;
+          }
+
+          summary.errors += 1;
+          await tx
+            .update(bets)
+            .set({ settlementError: message })
+            .where(eq(bets.id, bet.id));
+          processed.push({ id: bet.id, status: "ERROR", reason: message });
+        }
+      }
+
+      const lastBet = dueBets.at(-1);
+      const nextCursor = lastBet
+        ? `${typeof lastBet.endDate === "string" ? lastBet.endDate : formatISO(lastBet.endDate, { representation: "date" })}|${lastBet.id}`
+        : null;
+
+      return { summary, cursor: nextCursor, processed };
+    });
+
+    return NextResponse.json({
+      ...result.summary,
+      cursor: result.cursor,
+      processed: result.processed
+    });
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json({ error: error.flatten() }, { status: 400 });
+    }
+    console.error("Failed to settle due bets", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unable to settle bets" },
+      { status: 500 }
+    );
   }
+}
+
+export async function GET() {
+  return methodNotAllowed();
+}
+
+export async function PUT() {
+  return methodNotAllowed();
+}
+
+export async function PATCH() {
+  return methodNotAllowed();
+}
+
+export async function DELETE() {
+  return methodNotAllowed();
+}
+
+export async function HEAD() {
+  return methodNotAllowed();
 }

--- a/src/app/api/check/route.test.ts
+++ b/src/app/api/check/route.test.ts
@@ -1,99 +1,302 @@
 import { NextRequest } from "next/server";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi, afterEach } from "vitest";
 
-const historicalMock = vi.fn();
+import { resolveToTradingDay } from "@/lib/finance";
+import {
+  YahooNoDataError,
+  YahooSymbolNotFoundError,
+  YahooTransientError
+} from "@/lib/yahoo";
 
-vi.mock("yahoo-finance2", () => ({
-  default: {
-    historical: historicalMock
-  }
+const yahooMockState = vi.hoisted(() => ({
+  mockGetQuote: undefined as ReturnType<typeof vi.fn> | undefined
 }));
 
-const betRecord: any = {};
+type QuoteFixture = {
+  symbol: string;
+  date: Date;
+  price: number;
+};
 
-vi.mock("@/lib/db", () => {
+let currentFixtures: QuoteFixture[] = [];
+
+const lookupQuote = (symbol: string, date: Date) => {
+  const key = `${symbol}-${date.toISOString()}`;
+  const match = currentFixtures.find((fixture) => `${fixture.symbol}-${fixture.date.toISOString()}` === key);
+  if (!match) {
+    throw new YahooNoDataError(symbol);
+  }
   return {
-    db: {
-      query: {
-        bets: {
-          findFirst: vi.fn(async () => betRecord)
-        }
-      },
-      update: vi.fn(() => ({
-        set: (values: any) => ({
-          where: () => ({
-            returning: async () => {
-              Object.assign(betRecord, values);
-              return [betRecord];
-            }
-          })
-        })
-      }))
-    },
-    bets: {
-      id: { name: "id" }
-    }
+    date: match.date,
+    close: match.price,
+    adjClose: match.price
+  };
+};
+
+vi.mock("@/lib/yahoo", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/yahoo")>("@/lib/yahoo");
+  const getQuoteMock = vi.fn(async (symbol: string, date: Date) => lookupQuote(symbol, date));
+  yahooMockState.mockGetQuote = getQuoteMock;
+  return {
+    ...actual,
+    getAdjustedCloseOnOrBefore: getQuoteMock
   };
 });
 
-const initialBet = {
-  id: "123e4567-e89b-12d3-a456-426614174000",
-  bettorA: "Alice",
-  bettorB: "Bob",
-  tickerA: "AAPL",
-  tickerB: "MSFT",
-  startDate: new Date("2020-01-02T00:00:00Z"),
-  endDate: new Date("2020-01-10T00:00:00Z"),
-  createdAt: new Date("2020-01-01T00:00:00Z"),
-  status: "open" as const,
-  result: null
+const betRecord: any = {};
+const findFirstSpy = vi.fn();
+
+vi.mock("@/lib/db/client", () => ({
+  db: {
+    query: {
+      bets: {
+        findFirst: findFirstSpy
+      }
+    },
+    update: vi.fn(() => ({
+      set: (values: any) => ({
+        where: () => ({
+          returning: async () => {
+            Object.assign(betRecord, values);
+            return [betRecord];
+          }
+        })
+      })
+    }))
+  }
+}));
+
+const ensureYahooMock = () => {
+  const mockGetQuote = yahooMockState.mockGetQuote;
+  if (!mockGetQuote) {
+    throw new Error("Yahoo mock not initialized");
+  }
+  return mockGetQuote;
 };
 
-beforeEach(() => {
+const setQuoteFixtures = (fixtures: QuoteFixture[]) => {
+  currentFixtures = fixtures;
+  ensureYahooMock().mockImplementation(async (symbol: string, date: Date) => lookupQuote(symbol, date));
+};
+
+const initializeBet = (overrides: Partial<typeof betRecord> = {}) => {
   Object.assign(betRecord, {
-    ...initialBet,
-    startDate: new Date(initialBet.startDate),
-    endDate: new Date(initialBet.endDate),
-    createdAt: new Date(initialBet.createdAt),
-    status: "open",
-    result: null
+    id: "123e4567-e89b-12d3-a456-426614174000",
+    bettorA: "Alice",
+    bettorB: "Bob",
+    tickerA: "AAPL",
+    tickerB: "MSFT",
+    startDate: new Date("2020-01-02T00:00:00Z"),
+    endDate: new Date("2020-01-10T00:00:00Z"),
+    createdAt: new Date("2020-01-01T00:00:00Z"),
+    updatedAt: new Date("2020-01-01T00:00:00Z"),
+    settledAt: null,
+    settlementTxId: null,
+    settlementError: null,
+    status: "OPEN",
+    result: null,
+    ...overrides
+  });
+};
+
+const buildFixtures = (config: { start: string; end: string; a: { start: number; end: number }; b: { start: number; end: number } }) => {
+  const startTradingDayA = resolveToTradingDay(new Date(config.start), "next");
+  const endTradingDayA = resolveToTradingDay(new Date(config.end), "prev");
+  const startTradingDayB = startTradingDayA;
+  const endTradingDayB = endTradingDayA;
+
+  return [
+    { symbol: "AAPL", date: startTradingDayA, price: config.a.start },
+    { symbol: "AAPL", date: endTradingDayA, price: config.a.end },
+    { symbol: "MSFT", date: startTradingDayB, price: config.b.start },
+    { symbol: "MSFT", date: endTradingDayB, price: config.b.end }
+  ];
+};
+
+const createRequest = () =>
+  new NextRequest("http://localhost/api/check", {
+    method: "POST",
+    body: JSON.stringify({ id: betRecord.id }),
+    headers: new Headers({ "content-type": "application/json" })
   });
 
-  historicalMock.mockReset();
-  historicalMock.mockImplementation((ticker: string) => {
-    if (ticker === "AAPL") {
-      return Promise.resolve([
-        { date: new Date("2020-01-02T00:00:00Z"), close: 100, adjClose: 100 },
-        { date: new Date("2020-01-10T00:00:00Z"), close: 120, adjClose: 120 }
-      ]);
-    }
-    return Promise.resolve([
-      { date: new Date("2020-01-02T00:00:00Z"), close: 100, adjClose: 100 },
-      { date: new Date("2020-01-10T00:00:00Z"), close: 110, adjClose: 110 }
-    ]);
-  });
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2020-01-20T00:00:00Z"));
+  currentFixtures = [];
+  ensureYahooMock().mockReset();
+  findFirstSpy.mockReset();
+  findFirstSpy.mockImplementation(async () => betRecord);
+  initializeBet();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("POST /api/check", () => {
-  it("settles a bet using yahoo-finance data", async () => {
+  it("settles a bet using Yahoo Finance data", async () => {
+    setQuoteFixtures(
+      buildFixtures({
+        start: "2020-01-02",
+        end: "2020-01-10",
+        a: { start: 100, end: 120 },
+        b: { start: 90, end: 99 }
+      })
+    );
+
     const { POST } = await import("./route");
-    const request = new NextRequest("http://localhost/api/check", {
-      method: "POST",
-      body: JSON.stringify({ id: betRecord.id }),
-      headers: new Headers({ "content-type": "application/json" })
-    });
+    const request = createRequest();
 
     const response = await POST(request);
+    expect(response.status).toBe(200);
+    const data = (await response.json()) as typeof betRecord;
 
+    expect(data.status).toBe("SETTLED");
+    expect(data.result?.winner).toBe("A");
+    expect(data.result?.a.rounded).toBeCloseTo(0.2);
+    expect(data.result?.b.rounded).toBeCloseTo(0.1);
+    expect(betRecord.status).toBe("SETTLED");
+    expect(ensureYahooMock()).toHaveBeenCalledTimes(4);
+  });
+
+  it("settles when the end date falls on a weekend", async () => {
+    initializeBet({
+      startDate: new Date("2020-01-02T00:00:00Z"),
+      endDate: new Date("2020-01-05T00:00:00Z")
+    });
+
+    setQuoteFixtures(
+      buildFixtures({
+        start: "2020-01-02",
+        end: "2020-01-05",
+        a: { start: 50, end: 55 },
+        b: { start: 40, end: 35 }
+      })
+    );
+
+    const { POST } = await import("./route");
+    const request = createRequest();
+
+    const response = await POST(request);
     expect(response.status).toBe(200);
     const data = await response.json();
 
-    expect(data.status).toBe("completed");
-    expect(data.result.winner).toBe("A");
-    expect(data.result.aReturn).toBeCloseTo(0.2);
-    expect(data.result.bReturn).toBeCloseTo(0.1);
-    expect(betRecord.status).toBe("completed");
-    expect(betRecord.result).toEqual(data.result);
-    expect(historicalMock).toHaveBeenCalledTimes(2);
+    expect(data.status).toBe("SETTLED");
+    expect(data.result.a.rounded).toBeCloseTo(0.1);
+    expect(data.result.b.rounded).toBeCloseTo(-0.125);
+  });
+
+  it("handles ranges that resolve to the same trading day", async () => {
+    initializeBet({
+      startDate: new Date("2020-01-03T00:00:00Z"),
+      endDate: new Date("2020-01-04T00:00:00Z")
+    });
+
+    setQuoteFixtures(
+      buildFixtures({
+        start: "2020-01-03",
+        end: "2020-01-03",
+        a: { start: 70, end: 70 },
+        b: { start: 80, end: 80 }
+      })
+    );
+
+    const { POST } = await import("./route");
+    const request = createRequest();
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.status).toBe("SETTLED");
+    expect(data.result.a.rounded).toBe(0);
+    expect(data.result.b.rounded).toBe(0);
+  });
+
+  it("marks a bet invalid when a ticker is not found", async () => {
+    setQuoteFixtures(
+      buildFixtures({
+        start: "2020-01-02",
+        end: "2020-01-10",
+        a: { start: 100, end: 120 },
+        b: { start: 90, end: 99 }
+      })
+    );
+
+    ensureYahooMock().mockImplementation(async (symbol: string, date: Date) => {
+      if (symbol === "AAPL") {
+        throw new YahooSymbolNotFoundError(symbol);
+      }
+      return lookupQuote(symbol, date);
+    });
+
+    const { POST } = await import("./route");
+    const request = createRequest();
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.status).toBe("INVALID");
+    expect(betRecord.status).toBe("INVALID");
+    expect(betRecord.settlementError).toContain("No data");
+  });
+
+  it("returns a pending response when Yahoo data is not yet available", async () => {
+    setQuoteFixtures(
+      buildFixtures({
+        start: "2020-01-02",
+        end: "2020-01-10",
+        a: { start: 100, end: 120 },
+        b: { start: 100, end: 100 }
+      })
+    );
+
+    const endTradingDay = resolveToTradingDay(new Date("2020-01-10"), "prev");
+
+    ensureYahooMock().mockImplementation(async (symbol: string, date: Date) => {
+      if (symbol === "AAPL" && date.toISOString() === endTradingDay.toISOString()) {
+        throw new YahooTransientError("awaiting close");
+      }
+      return lookupQuote(symbol, date);
+    });
+
+    const { POST } = await import("./route");
+    const request = createRequest();
+
+    const response = await POST(request);
+    expect(response.status).toBe(202);
+    const data = await response.json();
+
+    expect(data.status).toBe("PENDING");
+    expect(betRecord.status).toBe("OPEN");
+    expect(betRecord.settlementError).toContain("awaiting close");
+  });
+
+  it("is idempotent when the bet is already settled", async () => {
+    setQuoteFixtures(
+      buildFixtures({
+        start: "2020-01-02",
+        end: "2020-01-10",
+        a: { start: 100, end: 105 },
+        b: { start: 95, end: 94 }
+      })
+    );
+
+    const { POST } = await import("./route");
+    const firstRequest = createRequest();
+
+    await POST(firstRequest);
+
+    ensureYahooMock().mockClear();
+    findFirstSpy.mockImplementation(async () => ({ ...betRecord }));
+
+    const secondResponse = await POST(createRequest());
+    expect(secondResponse.status).toBe(200);
+    const payload = await secondResponse.json();
+
+    expect(payload.status).toBe("SETTLED");
+    expect(ensureYahooMock()).not.toHaveBeenCalled();
   });
 });

--- a/src/components/TickerAutocomplete.tsx
+++ b/src/components/TickerAutocomplete.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 
 type Suggestion = {
   symbol: string;
@@ -32,6 +32,7 @@ export default function TickerAutocomplete({
   const [loading, setLoading] = useState(false);
   const [items, setItems] = useState<Suggestion[]>([]);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const listId = useId();
 
   useEffect(() => {
     function onDocClick(e: MouseEvent) {
@@ -99,14 +100,20 @@ export default function TickerAutocomplete({
         id={id}
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        onBlur={(e) => onChange(e.target.value.toUpperCase())}
         placeholder={placeholder}
         autoComplete="off"
         className="w-full rounded border px-3 py-2"
         onFocus={() => value && setOpen(true)}
+        aria-autocomplete="list"
+        aria-expanded={open}
+        role="combobox"
+        aria-controls={open ? listId : undefined}
       />
       {open && items.length > 0 && (
         <ul
           role="listbox"
+          id={listId}
           className="absolute z-50 mt-1 max-h-64 w-full overflow-auto rounded border bg-white shadow"
         >
           {items.map((s, idx) => {
@@ -115,6 +122,7 @@ export default function TickerAutocomplete({
               <li
                 key={`${s.symbol}-${idx}`}
                 role="option"
+                aria-selected="false"
                 tabIndex={0}
                 onClick={() => handlePick(s)}
                 onKeyDown={(e) => e.key === "Enter" && handlePick(s)}

--- a/src/lib/__tests__/finance.test.ts
+++ b/src/lib/__tests__/finance.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  InvalidPriceError,
+  calculateReturn,
+  resolveToTradingDay,
+  tradingDayKey
+} from "@/lib/finance";
+
+const iso = (date: Date) => tradingDayKey(date);
+
+describe("resolveToTradingDay", () => {
+  it("returns the same date for an active trading day when moving forward", () => {
+    const day = resolveToTradingDay(new Date("2024-05-15T12:00:00Z"), "next");
+    expect(iso(day)).toBe("2024-05-15");
+  });
+
+  it("returns the previous trading day for a Saturday", () => {
+    const saturday = new Date("2024-05-18T00:00:00Z");
+    const resolved = resolveToTradingDay(saturday, "prev");
+    expect(iso(resolved)).toBe("2024-05-17");
+  });
+
+  it("returns the following trading day for a Sunday", () => {
+    const sunday = new Date("2024-05-19T00:00:00Z");
+    const resolved = resolveToTradingDay(sunday, "next");
+    expect(iso(resolved)).toBe("2024-05-20");
+  });
+
+  it("skips Independence Day when moving forward", () => {
+    const holiday = new Date("2024-07-04T00:00:00Z");
+    const forward = resolveToTradingDay(holiday, "next");
+    const backward = resolveToTradingDay(holiday, "prev");
+    expect(iso(forward)).toBe("2024-07-05");
+    expect(iso(backward)).toBe("2024-07-03");
+  });
+
+  it("skips Thanksgiving when determining trading days", () => {
+    const holiday = new Date("2024-11-28T00:00:00Z");
+    const forward = resolveToTradingDay(holiday, "next");
+    const backward = resolveToTradingDay(holiday, "prev");
+    expect(iso(forward)).toBe("2024-11-29");
+    expect(iso(backward)).toBe("2024-11-27");
+  });
+});
+
+describe("calculateReturn", () => {
+  it("returns raw and rounded gains", () => {
+    const start = { date: new Date("2024-01-02T00:00:00Z"), close: 100, adjClose: 100 };
+    const end = { date: new Date("2024-01-10T00:00:00Z"), close: 110, adjClose: 110 };
+    const result = calculateReturn(start, end);
+    expect(result.raw).toBeCloseTo(0.1);
+    expect(result.rounded).toBe(0.1);
+  });
+
+  it("throws when the start price is zero", () => {
+    const start = { date: new Date("2024-01-02T00:00:00Z"), close: 0, adjClose: 0 };
+    const end = { date: new Date("2024-01-10T00:00:00Z"), close: 110, adjClose: 110 };
+    expect(() => calculateReturn(start, end)).toThrow(InvalidPriceError);
+  });
+});

--- a/src/lib/__tests__/tickers.test.ts
+++ b/src/lib/__tests__/tickers.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeToYahoo } from "@/lib/tickers";
+
+describe("normalizeToYahoo", () => {
+  it("uppercases and trims symbols", () => {
+    expect(normalizeToYahoo(" goog ")).toBe("GOOG");
+  });
+
+  it("maps share classes with dots to hyphenated symbols", () => {
+    expect(normalizeToYahoo("brk.b")).toBe("BRK-B");
+    expect(normalizeToYahoo("BF.B")).toBe("BF-B");
+  });
+
+  it("maps GOOGLE to the class A ticker", () => {
+    expect(normalizeToYahoo("google")).toBe("GOOGL");
+  });
+
+  it("throws on unsupported characters", () => {
+    expect(() => normalizeToYahoo("BAD$")).toThrow(/Ticker must contain only letters/);
+  });
+});

--- a/src/lib/db/client.ts
+++ b/src/lib/db/client.ts
@@ -1,6 +1,32 @@
-import { sql } from "@vercel/postgres";
-import { drizzle } from "drizzle-orm/vercel-postgres";
+import { Pool } from "@vercel/postgres";
+import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
 
 import * as schema from "./schema";
 
-export const db = drizzle({ client: sql, schema });
+declare global {
+  // eslint-disable-next-line no-var
+  var __dbPool__: Pool | undefined;
+  // eslint-disable-next-line no-var
+  var __db__: NodePgDatabase<typeof schema> | undefined;
+}
+
+const connectionString = process.env.POSTGRES_URL;
+
+if (!connectionString) {
+  throw new Error(
+    "POSTGRES_URL is not defined. Set POSTGRES_URL (pooled connection string) in your runtime environment to connect to the database."
+  );
+}
+
+const pool = globalThis.__dbPool__ ?? new Pool({ connectionString });
+const db = globalThis.__db__ ?? drizzle(pool, { schema });
+
+if (!globalThis.__dbPool__) {
+  globalThis.__dbPool__ = pool;
+}
+
+if (!globalThis.__db__) {
+  globalThis.__db__ = db;
+}
+
+export { db, pool };

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -1,5 +1,6 @@
 import * as schema from "./schema";
 
-export { db } from "./client";
+export { db, pool } from "./client";
 export const { bets } = schema;
-export type { Bet, BetResult, NewBet } from "./schema";
+export { betStatusEnum } from "./schema";
+export type { Bet, BetLegResult, BetResult, NewBet, QuoteSnapshot } from "./schema";

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,37 +1,66 @@
 import { sql } from "drizzle-orm";
 import {
+  check,
+  date,
+  index,
+  jsonb,
   pgEnum,
   pgTable,
   text,
   timestamp,
   uuid,
-  date,
-  jsonb
+  varchar
 } from "drizzle-orm/pg-core";
 import { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
-export const betStatusEnum = pgEnum("bet_status", ["open", "completed"]);
+export const betStatusEnum = pgEnum("bet_status", ["OPEN", "SETTLED", "INVALID"]);
 
-export const bets = pgTable("bets", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  createdAt: timestamp("created_at", { withTimezone: false })
-    .notNull()
-    .default(sql`now()`),
-  bettorA: text("bettor_a").notNull(),
-  bettorB: text("bettor_b").notNull(),
-  tickerA: text("ticker_a").notNull(),
-  tickerB: text("ticker_b").notNull(),
-  startDate: date("start_date").notNull(),
-  endDate: date("end_date").notNull(),
-  status: betStatusEnum("status").notNull().default("open"),
-  result: jsonb("result").$type<BetResult | null>().default(sql`null`)
-});
+export const bets = pgTable(
+  "bets",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    createdAt: timestamp("created_at", { withTimezone: false }).notNull().default(sql`now()`),
+    updatedAt: timestamp("updated_at", { withTimezone: false })
+      .notNull()
+      .default(sql`now()`)
+      .$onUpdate(() => new Date()),
+    settledAt: timestamp("settled_at", { withTimezone: false }),
+    settlementTxId: uuid("settlement_tx_id"),
+    bettorA: varchar("bettor_a", { length: 80 }).notNull(),
+    bettorB: varchar("bettor_b", { length: 80 }).notNull(),
+    tickerA: varchar("ticker_a", { length: 16 }).notNull(),
+    tickerB: varchar("ticker_b", { length: 16 }).notNull(),
+    startDate: date("start_date").notNull(),
+    endDate: date("end_date").notNull(),
+    status: betStatusEnum("status").notNull().default("OPEN"),
+    settlementError: text("settlement_error"),
+    result: jsonb("result").$type<BetResult | null>().default(sql`null`)
+  },
+  (table) => ({
+    statusEndDateIdx: index("idx_bets_status_enddate").on(table.status, table.endDate),
+    enforceDateOrder: check("chk_bets_end_after_start", sql`${table.endDate} > ${table.startDate}`)
+  })
+);
 
 export type Bet = InferSelectModel<typeof bets>;
 export type NewBet = InferInsertModel<typeof bets>;
 
+export type QuoteSnapshot = {
+  date: string;
+  close: number;
+  adjClose: number;
+};
+
+export type BetLegResult = {
+  ticker: string;
+  start: QuoteSnapshot;
+  end: QuoteSnapshot;
+  raw: number;
+  rounded: number;
+};
+
 export type BetResult = {
-  aReturn: number;
-  bReturn: number;
+  a: BetLegResult;
+  b: BetLegResult;
   winner: "A" | "B" | "Tie";
 };

--- a/src/lib/finance.ts
+++ b/src/lib/finance.ts
@@ -1,68 +1,192 @@
-import yahooFinance from "yahoo-finance2";
-import { addDays, subDays } from "date-fns";
+import { addDays } from "date-fns";
+import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 
-export type Quote = {
-  date: Date;
-  adjClose: number | null;
-  close: number;
-};
+import type { QuoteSnapshot } from "@/lib/db";
+import { getAdjustedCloseOnOrBefore, type YahooQuote } from "./yahoo";
 
-export type TradingWindow = {
-  startQuote: Quote;
-  endQuote: Quote;
-};
+const TIME_ZONE = "America/New_York";
+const MAX_TRADING_DAY_LOOKUP = 366;
 
-function normalizeQuote(raw: yahooFinance.YahooHistoricalRow): Quote {
+const holidayCache = new Map<number, Set<string>>();
+
+export class InvalidPriceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidPriceError";
+  }
+}
+
+export class TradingDayResolutionError extends Error {
+  constructor(date: Date) {
+    super(`Could not resolve trading day for ${date.toISOString()}`);
+    this.name = "TradingDayResolutionError";
+  }
+}
+
+const MILLIS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function isoInNy(date: Date) {
+  return formatInTimeZone(date, TIME_ZONE, "yyyy-MM-dd");
+}
+
+export function tradingDayKey(date: Date) {
+  return isoInNy(date);
+}
+
+function isoYear(date: Date) {
+  return Number(formatInTimeZone(date, TIME_ZONE, "yyyy"));
+}
+
+function toNyMidnight(date: Date) {
+  const iso = date.toISOString().slice(0, 10);
+  return fromZonedTime(`${iso}T00:00:00`, TIME_ZONE);
+}
+
+function nyDate(year: number, month: number, day: number) {
+  const paddedMonth = `${month}`.padStart(2, "0");
+  const paddedDay = `${day}`.padStart(2, "0");
+  return fromZonedTime(`${year}-${paddedMonth}-${paddedDay}T00:00:00`, TIME_ZONE);
+}
+
+function nthWeekdayOfMonth(year: number, month: number, weekday: number, nth: number) {
+  const firstOfMonth = nyDate(year, month, 1);
+  const firstWeekday = Number(formatInTimeZone(firstOfMonth, TIME_ZONE, "i")); // 1 (Mon) - 7 (Sun)
+  const offset = (weekday - firstWeekday + 7) % 7;
+  const day = 1 + offset + (nth - 1) * 7;
+  return nyDate(year, month, day);
+}
+
+function lastWeekdayOfMonth(year: number, month: number, weekday: number) {
+  const daysInMonth = new Date(year, month, 0).getDate();
+  const lastOfMonth = nyDate(year, month, daysInMonth);
+  const lastWeekday = Number(formatInTimeZone(lastOfMonth, TIME_ZONE, "i"));
+  const offset = (lastWeekday - weekday + 7) % 7;
+  const day = daysInMonth - offset;
+  return nyDate(year, month, day);
+}
+
+function observedFixedHoliday(year: number, month: number, day: number) {
+  const base = nyDate(year, month, day);
+  const weekday = Number(formatInTimeZone(base, TIME_ZONE, "i"));
+  if (weekday === 6) {
+    // Saturday observed on Friday
+    return addDays(base, -1);
+  }
+  if (weekday === 7) {
+    // Sunday observed on Monday
+    return addDays(base, 1);
+  }
+  return base;
+}
+
+function calculateEaster(year: number) {
+  // Anonymous Gregorian algorithm
+  const a = year % 19;
+  const b = Math.floor(year / 100);
+  const c = year % 100;
+  const d = Math.floor(b / 4);
+  const e = b % 4;
+  const f = Math.floor((b + 8) / 25);
+  const g = Math.floor((b - f + 1) / 3);
+  const h = (19 * a + b - d - g + 15) % 30;
+  const i = Math.floor(c / 4);
+  const k = c % 4;
+  const l = (32 + 2 * e + 2 * i - h - k) % 7;
+  const m = Math.floor((a + 11 * h + 22 * l) / 451);
+  const month = Math.floor((h + l - 7 * m + 114) / 31);
+  const day = ((h + l - 7 * m + 114) % 31) + 1;
+  return nyDate(year, month, day);
+}
+
+function buildHolidaySet(year: number) {
+  if (holidayCache.has(year)) {
+    return holidayCache.get(year)!;
+  }
+
+  const holidays = new Set<string>();
+
+  const addIfSameYear = (date: Date) => {
+    const iso = isoInNy(date);
+    if (isoYear(date) === year) {
+      holidays.add(iso);
+    }
+  };
+
+  addIfSameYear(observedFixedHoliday(year, 1, 1)); // New Year's Day
+  addIfSameYear(observedFixedHoliday(year + 1, 1, 1)); // New Year's observed that falls in prior year
+  addIfSameYear(nthWeekdayOfMonth(year, 1, 1, 3)); // Martin Luther King Jr. Day
+  addIfSameYear(nthWeekdayOfMonth(year, 2, 1, 3)); // Presidents' Day
+  addIfSameYear(addDays(calculateEaster(year), -2)); // Good Friday
+  addIfSameYear(lastWeekdayOfMonth(year, 5, 1)); // Memorial Day
+  addIfSameYear(observedFixedHoliday(year, 6, 19)); // Juneteenth
+  addIfSameYear(observedFixedHoliday(year, 7, 4)); // Independence Day
+  addIfSameYear(nthWeekdayOfMonth(year, 9, 1, 1)); // Labor Day
+  addIfSameYear(nthWeekdayOfMonth(year, 11, 4, 4)); // Thanksgiving
+  addIfSameYear(observedFixedHoliday(year, 12, 25)); // Christmas
+
+  holidayCache.set(year, holidays);
+  return holidays;
+}
+
+function isTradingHoliday(date: Date) {
+  const iso = isoInNy(date);
+  const year = isoYear(date);
+  const holidays = buildHolidaySet(year);
+  return holidays.has(iso);
+}
+
+function isTradingDay(date: Date) {
+  const weekday = Number(formatInTimeZone(date, TIME_ZONE, "i")); // 1 (Mon) - 7 (Sun)
+  if (weekday >= 6) {
+    return false;
+  }
+  return !isTradingHoliday(date);
+}
+
+export function resolveToTradingDay(input: Date, direction: "next" | "prev" = "next"): Date {
+  let cursor = toNyMidnight(input);
+
+  for (let step = 0; step < MAX_TRADING_DAY_LOOKUP; step += 1) {
+    if (isTradingDay(cursor)) {
+      return cursor;
+    }
+    cursor = direction === "next" ? addDays(cursor, 1) : addDays(cursor, -1);
+  }
+
+  throw new TradingDayResolutionError(input);
+}
+
+export function toQuoteSnapshot(quote: YahooQuote): QuoteSnapshot {
   return {
-    date: raw.date instanceof Date ? raw.date : new Date(raw.date),
-    adjClose: raw.adjClose ?? null,
-    close: raw.close
+    date: quote.date.toISOString(),
+    close: Number(quote.close.toFixed(6)),
+    adjClose: Number(quote.adjClose.toFixed(6))
   };
 }
 
-function toDate(date: Date | string) {
-  return date instanceof Date ? date : new Date(date);
-}
+export type PriceReturn = {
+  raw: number;
+  rounded: number;
+};
 
-export async function resolveTradingWindow(
-  ticker: string,
-  startDate: Date | string,
-  endDate: Date | string
-): Promise<TradingWindow> {
-  const start = toDate(startDate);
-  const end = toDate(endDate);
+export function calculateReturn(start: YahooQuote, end: YahooQuote): PriceReturn {
+  const startPrice = start.adjClose;
+  const endPrice = end.adjClose;
 
-  const period1 = subDays(start, 10);
-  const period2 = addDays(end, 10);
-
-  const rows = await yahooFinance.historical(ticker, {
-    period1,
-    period2,
-    interval: "1d"
-  });
-
-  const quotes = rows.map(normalizeQuote).sort((a, b) => a.date.getTime() - b.date.getTime());
-
-  const startQuote = quotes.find((quote) => quote.date >= start);
-  const endQuote = [...quotes].reverse().find((quote) => quote.date <= end);
-
-  if (!startQuote || !endQuote) {
-    throw new Error(`No trading data available for ${ticker} in the requested range.`);
+  if (!Number.isFinite(startPrice) || startPrice <= 0) {
+    throw new InvalidPriceError("Start price is missing or zero");
+  }
+  if (!Number.isFinite(endPrice)) {
+    throw new InvalidPriceError("End price is missing");
   }
 
+  const raw = (endPrice - startPrice) / startPrice;
   return {
-    startQuote,
-    endQuote
+    raw,
+    rounded: Number(raw.toFixed(4))
   };
 }
 
-export function calculateReturn(start: Quote, end: Quote) {
-  const startPrice = start.adjClose ?? start.close;
-  const endPrice = end.adjClose ?? end.close;
-
-  if (startPrice === 0) {
-    throw new Error("Start price is zero, cannot compute return");
-  }
-
-  return (endPrice - startPrice) / startPrice;
+export async function getQuoteOnOrBefore(symbol: string, tradingDay: Date) {
+  return getAdjustedCloseOnOrBefore(symbol, tradingDay);
 }

--- a/src/lib/services/settle-bet.ts
+++ b/src/lib/services/settle-bet.ts
@@ -1,53 +1,198 @@
-import { isAfter, startOfDay } from "date-fns";
-import { eq } from "drizzle-orm";
+import { randomUUID } from "crypto";
+import { and, eq, isNull } from "drizzle-orm";
+
+import { fromZonedTime } from "date-fns-tz";
+
 import { bets, db, type Bet, type BetResult } from "@/lib/db";
-import { calculateReturn, resolveTradingWindow } from "@/lib/finance";
+import {
+  InvalidPriceError,
+  calculateReturn,
+  getQuoteOnOrBefore,
+  resolveToTradingDay,
+  toQuoteSnapshot,
+  tradingDayKey
+} from "@/lib/finance";
+import {
+  YahooNoDataError,
+  YahooSymbolNotFoundError,
+  YahooTransientError
+} from "@/lib/yahoo";
 
 export class BetNotMaturedError extends Error {
   constructor() {
-    super("Bet end date is in the future");
+    super("Bet end date has not passed");
     this.name = "BetNotMaturedError";
   }
 }
 
-export async function computeBetResult(bet: Bet): Promise<BetResult> {
-  const today = startOfDay(new Date());
-  const betEnd = startOfDay(new Date(bet.endDate));
+export type SettlementPending = {
+  status: "PENDING";
+  bet: Bet;
+  reason: string;
+};
 
-  if (isAfter(betEnd, today)) {
-    throw new BetNotMaturedError();
+export type SettlementResult =
+  | { status: "SETTLED"; bet: Bet }
+  | { status: "INVALID"; bet: Bet }
+  | SettlementPending;
+
+type DbClient = typeof db;
+
+const MARKET_TIME_ZONE = "America/New_York";
+
+function normalizeDate(value: Date | string) {
+  if (value instanceof Date) {
+    return value;
   }
 
-  const [windowA, windowB] = await Promise.all([
-    resolveTradingWindow(bet.tickerA, bet.startDate, bet.endDate),
-    resolveTradingWindow(bet.tickerB, bet.startDate, bet.endDate)
-  ]);
-
-  const aReturn = calculateReturn(windowA.startQuote, windowA.endQuote);
-  const bReturn = calculateReturn(windowB.startQuote, windowB.endQuote);
-
-  let winner: BetResult["winner"] = "Tie";
-  if (Math.abs(aReturn - bReturn) > 1e-8) {
-    winner = aReturn > bReturn ? "A" : "B";
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return fromZonedTime(`${value}T00:00:00`, MARKET_TIME_ZONE);
   }
 
-  return {
-    aReturn,
-    bReturn,
-    winner
-  };
+  return new Date(value);
 }
 
-export async function settleBet(bet: Bet) {
-  const result = await computeBetResult(bet);
-  const [updated] = await db
+async function markInvalid(client: DbClient, bet: Bet, reason: string) {
+  const now = new Date();
+  const [updated] = await client
     .update(bets)
     .set({
-      status: "completed",
-      result
+      status: "INVALID",
+      settledAt: now,
+      settlementTxId: randomUUID(),
+      settlementError: reason,
+      result: null
     })
+    .where(and(eq(bets.id, bet.id), isNull(bets.settledAt)))
+    .returning();
+
+  if (updated) {
+    return { status: "INVALID" as const, bet: updated };
+  }
+
+  const existing = await client.query.bets.findFirst({ where: eq(bets.id, bet.id) });
+  return { status: "INVALID" as const, bet: existing ?? bet };
+}
+
+async function markPending(client: DbClient, bet: Bet, reason: string): Promise<SettlementPending> {
+  const [updated] = await client
+    .update(bets)
+    .set({ settlementError: reason })
     .where(eq(bets.id, bet.id))
     .returning();
 
-  return updated;
+  return {
+    status: "PENDING" as const,
+    reason,
+    bet: updated ?? bet
+  };
+}
+
+async function markSettled(client: DbClient, bet: Bet, result: BetResult) {
+  const now = new Date();
+  const [updated] = await client
+    .update(bets)
+    .set({
+      status: "SETTLED",
+      settledAt: now,
+      settlementTxId: randomUUID(),
+      result,
+      settlementError: null
+    })
+    .where(and(eq(bets.id, bet.id), isNull(bets.settledAt)))
+    .returning();
+
+  if (updated) {
+    return { status: "SETTLED" as const, bet: updated };
+  }
+
+  const existing = await client.query.bets.findFirst({ where: eq(bets.id, bet.id) });
+  return { status: "SETTLED" as const, bet: existing ?? bet };
+}
+
+export async function computeBetResult(bet: Bet) {
+  const startDate = normalizeDate(bet.startDate);
+  const endDate = normalizeDate(bet.endDate);
+
+  const startTradingDay = resolveToTradingDay(startDate, "next");
+  const endTradingDay = resolveToTradingDay(endDate, "prev");
+
+  if (startTradingDay.getTime() > endTradingDay.getTime()) {
+    throw new InvalidPriceError("No trading days exist in the requested range");
+  }
+
+  const latestTradingDay = resolveToTradingDay(new Date(), "prev");
+  if (endTradingDay.getTime() > latestTradingDay.getTime()) {
+    throw new BetNotMaturedError();
+  }
+
+  const [startQuoteA, startQuoteB, endQuoteA, endQuoteB] = await Promise.all([
+    getQuoteOnOrBefore(bet.tickerA, startTradingDay),
+    getQuoteOnOrBefore(bet.tickerB, startTradingDay),
+    getQuoteOnOrBefore(bet.tickerA, endTradingDay),
+    getQuoteOnOrBefore(bet.tickerB, endTradingDay)
+  ]);
+
+  if (tradingDayKey(startQuoteA.date) !== tradingDayKey(startTradingDay)) {
+    throw new InvalidPriceError(`Missing start price for ${bet.tickerA}`);
+  }
+  if (tradingDayKey(startQuoteB.date) !== tradingDayKey(startTradingDay)) {
+    throw new InvalidPriceError(`Missing start price for ${bet.tickerB}`);
+  }
+  if (tradingDayKey(endQuoteA.date) !== tradingDayKey(endTradingDay)) {
+    throw new YahooTransientError(`Awaiting close data for ${bet.tickerA}`);
+  }
+  if (tradingDayKey(endQuoteB.date) !== tradingDayKey(endTradingDay)) {
+    throw new YahooTransientError(`Awaiting close data for ${bet.tickerB}`);
+  }
+
+  const aReturn = calculateReturn(startQuoteA, endQuoteA);
+  const bReturn = calculateReturn(startQuoteB, endQuoteB);
+
+  let winner: BetResult["winner"] = "Tie";
+  const diff = Math.abs(aReturn.raw - bReturn.raw);
+  if (diff > 1e-6) {
+    winner = aReturn.raw > bReturn.raw ? "A" : "B";
+  }
+
+  const result: BetResult = {
+    a: {
+      ticker: bet.tickerA,
+      start: toQuoteSnapshot(startQuoteA),
+      end: toQuoteSnapshot(endQuoteA),
+      raw: aReturn.raw,
+      rounded: aReturn.rounded
+    },
+    b: {
+      ticker: bet.tickerB,
+      start: toQuoteSnapshot(startQuoteB),
+      end: toQuoteSnapshot(endQuoteB),
+      raw: bReturn.raw,
+      rounded: bReturn.rounded
+    },
+    winner
+  };
+
+  return result;
+}
+
+export async function settleBet(bet: Bet, client: DbClient = db): Promise<SettlementResult> {
+  try {
+    const result = await computeBetResult(bet);
+    return await markSettled(client, bet, result);
+  } catch (error) {
+    if (error instanceof BetNotMaturedError) {
+      throw error;
+    }
+    if (error instanceof YahooTransientError) {
+      return markPending(client, bet, error.message);
+    }
+    if (error instanceof YahooSymbolNotFoundError || error instanceof YahooNoDataError) {
+      return markInvalid(client, bet, error.message);
+    }
+    if (error instanceof InvalidPriceError) {
+      return markInvalid(client, bet, error.message);
+    }
+    throw error;
+  }
 }

--- a/src/lib/tickers.ts
+++ b/src/lib/tickers.ts
@@ -1,0 +1,33 @@
+const EXCEPTION_MAP = new Map<string, string>([
+  ["BRK.B", "BRK-B"],
+  ["BRK-B", "BRK-B"],
+  ["BF.B", "BF-B"],
+  ["BF-B", "BF-B"],
+  ["GOOG", "GOOG"],
+  ["GOOGL", "GOOGL"],
+  ["GOOGLE", "GOOGL"]
+]);
+
+const VALID_SYMBOL = /^[A-Z0-9][A-Z0-9.\-]{0,9}$/;
+
+export function normalizeToYahoo(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error("Ticker cannot be empty");
+  }
+
+  const upper = trimmed.toUpperCase();
+  const compact = upper.replace(/\s+/g, "");
+
+  if (!VALID_SYMBOL.test(compact)) {
+    throw new Error("Ticker must contain only letters, numbers, dots, or hyphens");
+  }
+
+  const exception = EXCEPTION_MAP.get(compact);
+  if (exception) {
+    return exception;
+  }
+
+  const dotted = compact.replace(/\./g, "-").replace(/-+/g, "-");
+  return EXCEPTION_MAP.get(dotted) ?? dotted;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,7 +5,10 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export function formatPercent(value: number) {
-  const sign = value > 0 ? "+" : "";
+export function formatPercent(value: number | null | undefined) {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return "--";
+  }
+  const sign = value > 0 ? "+" : value < 0 ? "" : "";
   return `${sign}${(value * 100).toFixed(2)}%`;
 }

--- a/src/lib/yahoo.ts
+++ b/src/lib/yahoo.ts
@@ -1,0 +1,134 @@
+import { addDays } from "date-fns";
+
+import { normalizeToYahoo } from "./tickers";
+
+const CHART_ENDPOINT = "https://query1.finance.yahoo.com/v8/finance/chart/";
+const LOOKBACK_DAYS = 90;
+const MAX_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 200;
+
+export type YahooQuote = {
+  date: Date;
+  close: number;
+  adjClose: number;
+};
+
+export class YahooSymbolNotFoundError extends Error {
+  constructor(symbol: string) {
+    super(`No data found for symbol ${symbol}`);
+    this.name = "YahooSymbolNotFoundError";
+  }
+}
+
+export class YahooNoDataError extends Error {
+  constructor(symbol: string) {
+    super(`Unable to locate a price for ${symbol} on or before the requested date.`);
+    this.name = "YahooNoDataError";
+  }
+}
+
+export class YahooTransientError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "YahooTransientError";
+  }
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function buildUrl(symbol: string, start: Date, end: Date) {
+  const params = new URLSearchParams({
+    period1: Math.floor(start.getTime() / 1000).toString(),
+    period2: Math.floor(end.getTime() / 1000).toString(),
+    interval: "1d",
+    events: "div,splits",
+    includePrePost: "false"
+  });
+  return `${CHART_ENDPOINT}${encodeURIComponent(symbol)}?${params.toString()}`;
+}
+
+function parseQuote(symbol: string, body: any, targetEpoch: number): YahooQuote {
+  const result = body?.chart?.result?.[0];
+  const error = body?.chart?.error;
+
+  if (error) {
+    if (error.code === "Not Found") {
+      throw new YahooSymbolNotFoundError(symbol);
+    }
+    throw new YahooTransientError(error.description ?? "Yahoo Finance returned an error");
+  }
+
+  if (!result) {
+    throw new YahooNoDataError(symbol);
+  }
+
+  const timestamps: number[] = Array.isArray(result.timestamp) ? result.timestamp : [];
+  const quoteData = result.indicators?.quote?.[0] ?? {};
+  const adjData = result.indicators?.adjclose?.[0] ?? {};
+  const closes: Array<number | null | undefined> = Array.isArray(quoteData.close) ? quoteData.close : [];
+  const adjCloses: Array<number | null | undefined> = Array.isArray(adjData.adjclose) ? adjData.adjclose : [];
+
+  for (let i = timestamps.length - 1; i >= 0; i -= 1) {
+    const ts = timestamps[i];
+    if (typeof ts !== "number" || ts > targetEpoch) {
+      continue;
+    }
+    const close = closes[i];
+    const adjClose = adjCloses[i];
+    if (typeof close === "number" && Number.isFinite(close)) {
+      const resolvedAdj = typeof adjClose === "number" && Number.isFinite(adjClose) ? adjClose : close;
+      return {
+        date: new Date(ts * 1000),
+        close,
+        adjClose: resolvedAdj
+      };
+    }
+  }
+
+  throw new YahooNoDataError(symbol);
+}
+
+export async function getAdjustedCloseOnOrBefore(symbolInput: string, date: Date): Promise<YahooQuote> {
+  const normalized = normalizeToYahoo(symbolInput);
+  const targetDate = new Date(date);
+  const endRange = addDays(targetDate, 1);
+  const startRange = addDays(targetDate, -LOOKBACK_DAYS);
+  const targetEpoch = Math.floor(endRange.getTime() / 1000) - 1;
+
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt += 1) {
+    try {
+      const url = buildUrl(normalized, startRange, endRange);
+      const response = await fetch(url, {
+        headers: { Accept: "application/json" },
+        cache: "no-store"
+      });
+
+      if (!response.ok) {
+        if (response.status === 404 || response.status === 400) {
+          throw new YahooSymbolNotFoundError(normalized);
+        }
+        if (response.status === 429 || response.status >= 500) {
+          throw new YahooTransientError(`Yahoo Finance responded with status ${response.status}`);
+        }
+        throw new YahooTransientError(`Unexpected Yahoo Finance response: ${response.status}`);
+      }
+
+      const body = await response.json();
+      return parseQuote(normalized, body, targetEpoch);
+    } catch (error) {
+      if (error instanceof YahooSymbolNotFoundError || error instanceof YahooNoDataError) {
+        throw error;
+      }
+      lastError = error instanceof Error ? error : new YahooTransientError("Unknown error from Yahoo Finance");
+      if (attempt < MAX_RETRIES - 1) {
+        await sleep(RETRY_BASE_DELAY_MS * (attempt + 1));
+        continue;
+      }
+      throw lastError;
+    }
+  }
+
+  throw lastError ?? new YahooNoDataError(normalized);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -15,12 +19,28 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["vitest/globals"],
+    "types": [
+      "vitest/globals"
+    ],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
-    }
+      "@/*": [
+        "src/*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- normalize market-day calculations to snap ISO dates to New York midnights and respect holiday calendars when settling bets
- ensure bet date parsing treats YYYY-MM-DD strings as market-local dates and harden the Yahoo Finance mock wiring for API tests
- expand settlement route tests to cover weekend ranges, transient Yahoo responses, and idempotent re-checks while keeping fixtures reusable

## Testing
- npm run lint
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68ce3a8239648329b141071d247d3122