### PR TITLE
Refactor Postgres client to initialize at runtime

### DIFF
--- a/src/app/api/bets/route.ts
+++ b/src/app/api/bets/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { and, desc, eq, sql } from "drizzle-orm";
 import { betFormSchema, getBetsQuerySchema } from "@/lib/validation";
 import { bets } from "@/lib/db";
-import { db } from "@/lib/db/client";
+import { getDb } from "@/lib/db/client";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -12,6 +12,7 @@ export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
     const data = betFormSchema.parse(body);
+    const db = getDb();
 
     const [inserted] = await db
       .insert(bets)
@@ -43,6 +44,7 @@ export async function GET(req: NextRequest) {
       limit: searchParams.get("limit") ?? undefined,
       page: searchParams.get("page") ?? undefined
     });
+    const db = getDb();
 
     const offset = (query.page - 1) * query.limit;
     const filters = query.status ? [eq(bets.status, query.status)] : [];

--- a/src/app/api/check-due/route.ts
+++ b/src/app/api/check-due/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { and, eq, lt } from "drizzle-orm";
 import { startOfDay, subMilliseconds } from "date-fns";
 import { bets } from "@/lib/db";
-import { db } from "@/lib/db/client";
+import { getDb } from "@/lib/db/client";
 import { BetNotMaturedError, settleBet } from "@/lib/services/settle-bet";
 
 export const runtime = "nodejs";
@@ -14,6 +14,7 @@ export async function POST() {
   const endOfYesterday = subMilliseconds(today, 1);
 
   try {
+    const db = getDb();
     const dueBets = await db
       .select()
       .from(bets)

--- a/src/app/api/check/route.ts
+++ b/src/app/api/check/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { bets } from "@/lib/db";
-import { db } from "@/lib/db/client";
+import { getDb } from "@/lib/db/client";
 import { checkBetSchema } from "@/lib/validation";
 import { BetNotMaturedError, settleBet } from "@/lib/services/settle-bet";
 
@@ -13,6 +13,7 @@ export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
     const { id } = checkBetSchema.parse(body);
+    const db = getDb();
 
     const bet = await db.query.bets.findFirst({ where: eq(bets.id, id) });
 

--- a/src/lib/db/client.ts
+++ b/src/lib/db/client.ts
@@ -1,6 +1,16 @@
+// src/lib/db/client.ts
+// Server-only DB client for Vercel Postgres + Drizzle without build-time env reads.
+
 import { sql } from "@vercel/postgres";
 import { drizzle } from "drizzle-orm/vercel-postgres";
 
 import * as schema from "./schema";
 
-export const db = drizzle({ client: sql, schema });
+// No env reads at module scope. @vercel/postgres `sql` defers to runtime env.
+let _db: ReturnType<typeof drizzle> | null = null;
+
+export function getDb() {
+  if (_db) return _db;
+  _db = drizzle({ client: sql, schema });
+  return _db;
+}

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -1,5 +1,5 @@
 import * as schema from "./schema";
 
-export { db } from "./client";
+export { getDb } from "./client";
 export const { bets } = schema;
 export type { Bet, BetResult, NewBet } from "./schema";

--- a/src/lib/services/settle-bet.ts
+++ b/src/lib/services/settle-bet.ts
@@ -1,6 +1,7 @@
 import { isAfter, startOfDay } from "date-fns";
 import { eq } from "drizzle-orm";
-import { bets, db, type Bet, type BetResult } from "@/lib/db";
+import { bets, type Bet, type BetResult } from "@/lib/db";
+import { getDb } from "@/lib/db/client";
 import { calculateReturn, resolveTradingWindow } from "@/lib/finance";
 
 export class BetNotMaturedError extends Error {
@@ -40,6 +41,7 @@ export async function computeBetResult(bet: Bet): Promise<BetResult> {
 
 export async function settleBet(bet: Bet) {
   const result = await computeBetResult(bet);
+  const db = getDb();
   const [updated] = await db
     .update(bets)
     .set({


### PR DESCRIPTION
## Summary
- replace the eager drizzle client export with a lazy `getDb` helper backed by `@vercel/postgres`
- update server routes and services to pull the shared client at request time to avoid build-time env reads
- ensure shared db index re-exports `getDb` while keeping schema exports untouched

## Testing
- npm run lint *(fails: Failed to load config "next/typescript" to extend from.)*

------
https://chatgpt.com/codex/tasks/task_e_68ce704bad3c83299f298a7b2201e977